### PR TITLE
Add interface methods to code snippets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,23 @@ public void MyMethod(object arg1, object arg2, object arg3)  {
     throw new NotImplementedException();
 }
 ```
-### ex.2) Virtual instance method
+### ex.2) Interface method
+
+```csharp
+// Enter "imethod [Tab]", then...  
+public void MyMethod();
+
+// Enter "imethod1 [Tab]", then...  
+public void MyMethod(object arg);
+
+// Enter "imethod2 [Tab]", then...  
+public void MyMethod(object arg1, object arg2);
+
+// Enter "imethod3 [Tab]", then...  
+public void MyMethod(object arg1, object arg2, object arg3);
+```
+
+### ex.3) Virtual instance method
 
 ```csharp
 // Enter "vmethod [Tab]", then...  
@@ -78,7 +94,7 @@ public virtual void MyMethod(object arg1, object arg2, object arg3)  {
 }
 ```
 
-### ex.3) Static method
+### ex.4) Static method
 
 ```csharp
 // Enter "smethod [Tab]", then...  
@@ -101,7 +117,7 @@ public static void MyMethod(object arg1, object arg2, object arg3)  {
     throw new NotImplementedException();
 }
 ```
-### ex.4) Extension method
+### ex.5) Extension method
 
 ```csharp
 // Enter "xmethod [Tab]", then...  
@@ -125,7 +141,7 @@ public static void MyMethod(this object value, object arg1, object arg2, object 
 }
 ```
 
-### ex.5) Async instance method
+### ex.6) Async instance method
 
 ```csharp
 // Enter "amethod [Tab]", then...  
@@ -134,7 +150,7 @@ public async Task<object> MyMethodAsync()  {
 }
 ```
 
-### ex.6) Async static method
+### ex.7) Async static method
 
 ```csharp
 // Enter "asmethod [Tab]", then...  
@@ -143,7 +159,7 @@ public static async Task<object> MyMethodAsync()  {
 }
 ```
 
-### ex.7) Event handler, Static event handler
+### ex.8) Event handler, Static event handler
 
 ```csharp
 // Enter "eh [Tab]", then... 

--- a/src/csharp/methods/methods.snippet
+++ b/src/csharp/methods/methods.snippet
@@ -237,6 +237,226 @@
     </Snippet>
   </CodeSnippet>
 
+  <!-- imethod -->
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+      <Title>interface method</Title>
+      <Shortcut>imethod</Shortcut>
+      <Description>Code snippet for a interface method</Description>
+      <Author>Juan Ramos</Author>
+    </Header>
+    <Snippet>
+      <Imports>
+        <Import>
+          <Namespace>System</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>accessControll</ID>
+          <ToolTip>Replace with the access controll type</ToolTip>
+          <Default>public</Default>
+        </Literal>
+        <Literal>
+          <ID>returnType</ID>
+          <ToolTip>Replace with the type of the method return value</ToolTip>
+          <Default>void</Default>
+        </Literal>
+        <Literal>
+          <ID>name</ID>
+          <ToolTip>Replace with the name of the method</ToolTip>
+          <Default>MyMethod</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[$accessControll$ $returnType$ $name$(); $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+
+  <!-- imethod1 -->
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+      <Title>interface method with one argument</Title>
+      <Shortcut>imethod1</Shortcut>
+      <Description>Code snippet for a interface method with one argument</Description>
+      <Author>Juan Ramos</Author>
+    </Header>
+    <Snippet>
+      <Imports>
+        <Import>
+          <Namespace>System</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>accessControll</ID>
+          <ToolTip>Replace with the access controll type</ToolTip>
+          <Default>public</Default>
+        </Literal>
+        <Literal>
+          <ID>returnType</ID>
+          <ToolTip>Replace with the type of the method return value</ToolTip>
+          <Default>void</Default>
+        </Literal>
+        <Literal>
+          <ID>name</ID>
+          <ToolTip>Replace with the name of the method</ToolTip>
+          <Default>MyMethod</Default>
+        </Literal>
+        <Literal>
+          <ID>arg1Type</ID>
+          <ToolTip>Replace with the type of the 1st argument</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>arg1</ID>
+          <ToolTip>Replace with the name of the 1st argument</ToolTip>
+          <Default>arg1</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[$accessControll$ $returnType$ $name$($arg1Type$ $arg1$); $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+
+  <!-- imethod2 -->
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+      <Title>interface method with two arguments</Title>
+      <Shortcut>imethod2</Shortcut>
+      <Description>Code snippet for a interface method with two arguments</Description>
+      <Author>Juan Ramos</Author>
+    </Header>
+    <Snippet>
+      <Imports>
+        <Import>
+          <Namespace>System</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>accessControll</ID>
+          <ToolTip>Replace with the access controll type</ToolTip>
+          <Default>public</Default>
+        </Literal>
+        <Literal>
+          <ID>returnType</ID>
+          <ToolTip>Replace with the type of the method return value</ToolTip>
+          <Default>void</Default>
+        </Literal>
+        <Literal>
+          <ID>name</ID>
+          <ToolTip>Replace with the name of the method</ToolTip>
+          <Default>MyMethod</Default>
+        </Literal>
+        <Literal>
+          <ID>arg1Type</ID>
+          <ToolTip>Replace with the type of the 1st argument</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>arg1</ID>
+          <ToolTip>Replace with the name of the 1st argument</ToolTip>
+          <Default>arg1</Default>
+        </Literal>
+        <Literal>
+          <ID>arg2Type</ID>
+          <ToolTip>Replace with the type of the 2nd argument</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>arg2</ID>
+          <ToolTip>Replace with the name of the 2nd argument</ToolTip>
+          <Default>arg2</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[$accessControll$ $returnType$ $name$($arg1Type$ $arg1$, $arg2Type$ $arg2$); $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+
+  <!-- imethod3 -->
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+      <Title>interface method with three arguments</Title>
+      <Shortcut>imethod3</Shortcut>
+      <Description>Code snippet for a interface method with three arguments</Description>
+      <Author>Juan Ramos</Author>
+    </Header>
+    <Snippet>
+      <Imports>
+        <Import>
+          <Namespace>System</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal>
+          <ID>accessControll</ID>
+          <ToolTip>Replace with the access controll type</ToolTip>
+          <Default>public</Default>
+        </Literal>
+        <Literal>
+          <ID>returnType</ID>
+          <ToolTip>Replace with the type of the method return value</ToolTip>
+          <Default>void</Default>
+        </Literal>
+        <Literal>
+          <ID>name</ID>
+          <ToolTip>Replace with the name of the method</ToolTip>
+          <Default>MyMethod</Default>
+        </Literal>
+        <Literal>
+          <ID>arg1Type</ID>
+          <ToolTip>Replace with the type of the 1st argument</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>arg1</ID>
+          <ToolTip>Replace with the name of the 1st argument</ToolTip>
+          <Default>arg1</Default>
+        </Literal>
+        <Literal>
+          <ID>arg2Type</ID>
+          <ToolTip>Replace with the type of the 2nd argument</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>arg2</ID>
+          <ToolTip>Replace with the name of the 2nd argument</ToolTip>
+          <Default>arg2</Default>
+        </Literal>
+        <Literal>
+          <ID>arg3Type</ID>
+          <ToolTip>Replace with the type of the 3rd argument</ToolTip>
+          <Default>object</Default>
+        </Literal>
+        <Literal>
+          <ID>arg3</ID>
+          <ToolTip>Replace with the name of the 3rd argument</ToolTip>
+          <Default>arg3</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="csharp">
+        <![CDATA[$accessControll$ $returnType$ $name$($arg1Type$ $arg1$, $arg2Type$ $arg2$, $arg3Type$ $arg3$); $end$]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+
   <!-- vmethod -->
   <CodeSnippet Format="1.0.0">
     <Header>


### PR DESCRIPTION
```DIFF
+ // Enter "imethod [Tab]", then...  
+ public void MyMethod();

+ // Enter "imethod1 [Tab]", then...  
+ public void MyMethod(object arg);

+ // Enter "imethod2 [Tab]", then...  
+ public void MyMethod(object arg1, object arg2);

+ // Enter "imethod3 [Tab]", then...  
+ public void MyMethod(object arg1, object arg2, object arg3);
```